### PR TITLE
Support for projects in organizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ An easy to use [burndown chart](https://www.scrum.org/resources/scrum-glossary#:
 
 ## Features
 * Create a **burndown chart for a GitHub Project Board**.
-* Works for **private repositories**.
+* Works for projects in **private repositories** and **organizations**.
 * Includes a **trend line** for the current sprint.
 * Supports custom labels for **tracking points for issues**
 
@@ -66,9 +66,9 @@ pip install -r requirements.txt
 4. Make a copy of `src/config/config.json.dist` without the `.dist` ending.
     - This allows the `.gitignore` to exclude your `config.json` from being accidentally committed.
 5. Fill out all the configuration settings
-    - `repo_owner`: The username of the owner of the repo.
+    - `username`: The username of the organization or owner of the repo.
         - For example, `jhale1805`
-    - `repo_name`: The name of the repo.
+    - `repo_name`: The name of the repo. Leave blank if the project is in an organization instead of a repo.
         - For example, `github-projects-burndown-chart`
     - `project_number`: The id of the project for which you want to generate a burndown chart. This is found in the URL when looking at the project board on GitHub.
         - For example, `1` from [`https://github.com/jhale1805/github-projects-burndown-chart/projects/1`](https://github.com/jhale1805/github-projects-burndown-chart/projects/1)

--- a/src/config/config.json.dist
+++ b/src/config/config.json.dist
@@ -1,5 +1,5 @@
 {
-    "repo_owner": "",
+    "username": "",
     "repo_name": "",
     "project_number": 1,
     "sprint_start_date": "",

--- a/src/main.py
+++ b/src/main.py
@@ -1,12 +1,18 @@
 from chart.burndown import BurndownChart
 from config import config
-from gh.api_wrapper import get_project
+from gh.api_wrapper import get_repo_project, get_org_project
 
 if __name__ == '__main__':
-    project = get_project(
-        config['repo_owner'],
-        config['repo_name'],
-        config['project_number'])
+    repo_name = config['repo_name']
+    if repo_name:
+        project = get_project(
+            config['username'],
+            config['repo_name'],
+            config['project_number'])
+    else:
+        project = get_org_project(
+            config['username'],
+            config['project_number'])
     burndown_chart = BurndownChart(project)
     burndown_chart.render()
     print('Done')


### PR DESCRIPTION
I renamed `repo_owner` to `username`, so the terminology would fit these changes. This is a breaking change!

Also, I made it so that the tool looks for an organization if `repo_name` is left empty. Unfortunately, users may have to read the docs to understand this. Feel free to make suggestions or contributions for this.

I have updated the docs to reflect these changes.

Closes #14 